### PR TITLE
docs: fix tar command path in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,8 +48,8 @@ pip3 install -r requirements.txt
 
 mkdir build-iree-host-tools
 wget -i iree-release-link.txt -O build-iree-host-tools/iree-dist-linux-x86_64.tar.xz
-tar xvfJ iree-dist-linux-x86_64.tar.xz -C build-iree-host-tools
-rm iree-dist-linux-x86_64.tar.xz
+tar xvfJ build-iree-host-tools/iree-dist-linux-x86_64.tar.xz -C build-iree-host-tools
+rm build-iree-host-tools/iree-dist-linux-x86_64.tar.xz
 ```
 
 ###### Alternative: Use pip and install additional tools from source


### PR DESCRIPTION
The tar command was missing the full path to the downloaded file,
causing extraction to fail. Updated to use the correct path
build-iree-host-tools/iree-dist-linux-x86_64.tar.xz.
